### PR TITLE
Mention Mac-less builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 ## How do I use this?
 To use this app, you need to be on a supported version (mentioned above), and have [TrollStore](https://github.com/opa334/TrollStore/) installed. You can follow [this guide](https://ios.cfw.guide/installing-trollstore/) to install it on your device. Please note that this tool doesn't support iOS 17.0 despite of it having TrollStore.
 
-1. Download and install [Bootstrap from RootHide](https://github.com/RootHide/Bootstrap)
-2. Install ElleKit from Sileo
-3. Download the `.tipa` file from the [latest release](https://github.com/hrtowii/Serotonin/releases/latest)
-4. Install the downloaded file in TrollStore
-5. Open the app and press the Jelbrek button. Your device should userspace reboot, and you should be (not/semi) jailbroken!
+1. Build and install [Bootstrap from RootHide](https://github.com/dleovl/RootHideBootstrapUnofficialFAQ#how-do-i-build-the-roothide-bootstrap-no-pcmac-required)
+2. Press Bootstrap within the Bootstrap app
+3. Install ElleKit from within Sileo
+4. Download the `.tipa` file from the [latest release](https://github.com/hrtowii/Serotonin/releases/latest)
+5. Install the downloaded file in TrollStore
+6. Open the app and press the Jelbrek button. Your device should userspace reboot, and you should be (not/semi) jailbroken!
 
    
 ## How was this done? 


### PR DESCRIPTION
'Download and install' doesn't really fit with the RootHide Bootstrap since there's currently no way to download it manually (as it's in beta / no UI merged). This PR changes the link from the repository of the Bootstrap to a `.md` file with instructions for both GitHub Actions building and **(FIXED)** Xcode building.

It's important to give this information because you're eliminating the possibility that someone could install old, oudated, unsupported, or downright malicious versions of the Bootstrap (some pretty weird people have tried to get their own twist on it). [You can read about it more here](https://www.reddit.com/r/jailbreak/comments/18z28qk/discussion_do_not_use_other_peoples_roothide/).

Also made wording a little better in that area, I suppose.